### PR TITLE
Add sample budget data for user expense analysis

### DIFF
--- a/data/budget_analysis.ipynb
+++ b/data/budget_analysis.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20fe4e3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "\n",
+    "df = pd.read_csv(\"data/sample_budget.csv\")\n",
+    "df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d190e115",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "category_summary = df.groupby(\"Category\")[\"Amount_KES\"].sum().sort_values(ascending=False)\n",
+    "\n",
+    "# Pie chart\n",
+    "plt.figure(figsize=(8, 8))\n",
+    "plt.pie(category_summary, labels=category_summary.index, autopct='%1.1f%%', startangle=140)\n",
+    "plt.title(\"Spending Breakdown by Category\")\n",
+    "plt.axis(\"equal\")\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d5c5f5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Savings logic\n",
+    "total_income = 40000  \n",
+    "total_expenses = df[\"Amount_KES\"].sum()\n",
+    "suggested_savings = total_income * 0.2 \n",
+    "actual_savings = max(0, total_income - total_expenses)\n",
+    "\n",
+    "print(f\"Total Income: KES {total_income}\")\n",
+    "print(f\"Total Expenses: KES {total_expenses}\")\n",
+    "print(f\"Suggested Savings (20% rule): KES {suggested_savings}\")\n",
+    "print(f\"Actual Savings: KES {actual_savings}\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/data/sample_budget.csv
+++ b/data/sample_budget.csv
@@ -1,0 +1,13 @@
+Date,Category,Amount_KES
+2025-07-01,Rent,15000
+2025-07-02,Groceries,4500
+2025-07-03,Transport,1200
+2025-07-04,Utilities,2500
+2025-07-05,Entertainment,3000
+2025-07-06,Dining,2000
+2025-07-07,Healthcare,1800
+2025-07-08,Subscriptions,1200
+2025-07-09,Savings,4000
+2025-07-10,Education,3000
+2025-07-11,Loan Repayment,5000
+2025-07-12,Other,1300


### PR DESCRIPTION
This PR adds sample_budget.csv and budget_analysis.py to the data/ folder. The CSV contains sample categorized expense data. The script loads this data, visualizes it, and calculates savings vs. income using a 20% rule.